### PR TITLE
Fix i2cdev critical bugs

### DIFF
--- a/.eil.yml
+++ b/.eil.yml
@@ -1,6 +1,6 @@
 name: i2cdev
 description: ESP-IDF I2C master thread-safe utilities
-version: 2.1.0
+version: 2.1.1
 groups:
   - common
 code_owners:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "common"]
-	path = common
-	url = https://github.com/esp-idf-lib/common.git
+[submodule "eil-cmake-utils"]
+	path = eil-cmake-utils
+	url = https://github.com/esp-idf-lib/eil-cmake-utils.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # ESP-IDF CMake component for i2cdev library
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/eil-cmake-utils/cmake)
 
 # ESP-IDF version detection for automatic driver selection
 # Check for manual override via Kconfig
@@ -41,11 +42,4 @@ idf_component_register(SRCS ${SRCS}
                        INCLUDE_DIRS "."
                        REQUIRES ${req})
 
-
-# include common cmake file for components
-set(ESP_IDF_LIB_CMAKE ${CMAKE_CURRENT_LIST_DIR}/common/cmake/esp-idf-lib.cmake)
-if(EXISTS ${ESP_IDF_LIB_CMAKE})
-    include(${ESP_IDF_LIB_CMAKE})
-else()
-    message(WARNING "${ESP_IDF_LIB_CMAKE} not found")
-endif()
+include(eil_ci)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,4 @@
 # ESP-IDF CMake component for i2cdev library
-if(${IDF_VERSION_MAJOR} STREQUAL 5 AND ${IDF_VERSION_MINOR} LESS 3)
-    # Use driver component as esp_driver_gpio is not available before 5.3
-    set(req driver freertos log esp_timer)
-else()
-    set(req esp_driver_gpio esp_driver_i2c freertos esp_idf_lib_helpers)
-endif()
 
 # ESP-IDF version detection for automatic driver selection
 # Check for manual override via Kconfig
@@ -24,6 +18,13 @@ elseif(IDF_VERSION_MAJOR EQUAL 5 AND IDF_VERSION_MINOR LESS 3)
 else()
     set(USE_LEGACY_DRIVER FALSE)
     message(STATUS "i2cdev: ESP-IDF v${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR} detected, using new i2c_master driver")
+endif()
+
+# Conditionally set dependencies based on driver version
+if(USE_LEGACY_DRIVER)
+    set(req driver freertos esp_idf_lib_helpers)
+else()
+    set(req esp_driver_gpio esp_driver_i2c freertos esp_idf_lib_helpers)
 endif()
 
 # Conditionally set the source file based on version detection or Kconfig override

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ endif()
 
 # Conditionally set dependencies based on driver version
 if(USE_LEGACY_DRIVER)
-    set(req driver freertos esp_idf_lib_helpers)
+    set(req driver freertos log esp_idf_lib_helpers)
 else()
-    set(req esp_driver_gpio esp_driver_i2c freertos esp_idf_lib_helpers)
+    set(req esp_driver_gpio esp_driver_i2c freertos log esp_idf_lib_helpers)
 endif()
 
 # Conditionally set the source file based on version detection or Kconfig override

--- a/i2cdev.c
+++ b/i2cdev.c
@@ -906,6 +906,13 @@ esp_err_t i2cdev_get_shared_handle(i2c_port_t port, void **bus_handle)
 
     i2c_port_state_t *port_state = &i2c_ports[port];
 
+    // Check if i2cdev subsystem is initialized
+    if (port_state->lock == NULL)
+    {
+        ESP_LOGE(TAG, "[Port %d] I2C subsystem not initialized - call i2cdev_init() first", port);
+        return ESP_ERR_INVALID_STATE;
+    }
+
     // Take port mutex for thread-safe access
     if (xSemaphoreTake(port_state->lock, pdMS_TO_TICKS(CONFIG_I2CDEV_TIMEOUT)) != pdTRUE)
     {

--- a/i2cdev.h
+++ b/i2cdev.h
@@ -374,7 +374,8 @@ esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *data,
  * @param[out] bus_handle Pointer to store the bus handle
  * @return ESP_OK on success
  * @return ESP_ERR_INVALID_ARG if port is invalid or bus_handle is NULL
- * @return ESP_ERR_INVALID_STATE if bus for this port is not initialized yet
+ * @return ESP_ERR_INVALID_STATE if i2cdev_init() was not called or bus for this port is not initialized yet
+ * @return ESP_ERR_TIMEOUT if port mutex could not be acquired
  *
  * @warning The returned handle is managed by i2cdev. Do NOT call i2c_del_master_bus()
  *          on it directly - i2cdev will handle cleanup when the last device is removed.

--- a/i2cdev.h
+++ b/i2cdev.h
@@ -336,7 +336,6 @@ esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *data,
  * 4. Pass the handle to ESP-IDF components (e.g., esp_lcd_new_panel_io_i2c)
  *
  * @note USAGE EXAMPLE:
- * @code{c}
  * // 1. Initialize i2cdev
  * i2cdev_init();
  *
@@ -368,7 +367,6 @@ esp_err_t i2c_dev_write_reg(const i2c_dev_t *dev, uint8_t reg, const void *data,
  * ESP_ERROR_CHECK(esp_lcd_new_panel_io_i2c(bus_handle, &io_config, &io_handle));
  *
  * // Both the sensor and display now share the same I2C bus with proper synchronization!
- * @endcode
  *
  * @param port I2C port number (e.g., I2C_NUM_0)
  * @param[out] bus_handle Pointer to store the bus handle

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.0
+version: 2.1.1
 description: ESP-IDF I2C master thread-safe utilities
 license: MIT
 targets:
@@ -18,6 +18,7 @@ dependencies:
     version: "*"
 maintainers:
   - Ruslan V. Uss (@UncleRus) <unclerus@gmail.com>
+  - Piotr P. (@quinkq)
 url: https://github.com/esp-idf-lib/core
 repository: https://github.com/esp-idf-lib/i2cdev
 documentation: https://esp-idf-lib.github.io/i2cdev/


### PR DESCRIPTION
# Fix critical i2cdev bugs
While creating defensive checks for i2cdev_get_shared_handle, I started thinking about existing code, and added some potential safety. 
  - Add defensive NULL mutex checks (3 functions) to guard against calling I2C functions before `i2cdev_init()` (`i2c_setup_port`, `i2c_dev_delete_mutex`, `i2c_setup_device`)
  - Fix 3 possible NULL device pointer crashes in wrapper functions (`i2c_dev_read_reg`, `i2c_dev_write_reg`, `i2c_dev_probe`)
  - Fix reference counting asymmetry causing premature bus deletion when unused devices cleaned up  
  - Fix `i2cdev_init()` re-initialization leak with static guard flag
  - Include my threadsafe version of `i2cdev_get_shared_handle()`  with updated documentation (same as reviewed version in https://github.com/esp-idf-lib/i2cdev/pull/6)
  - Fix CMakeLists.txt ESP-IDF 4.x version detection (would be falling through to modern driver due to undefined IDF_VERSION_MAJOR)
  
  Code changes are minimal and version-independent. Tested on: ESP-IDF 5.4
  CMakeLists.txt changes target 4.x compatibility but untested on 4.x.