### PR TITLE
Fix LP_I2C_NUM_0 support: use LP_I2C_SCLK_DEFAULT clock source

### DIFF
--- a/i2cdev.c
+++ b/i2cdev.c
@@ -423,12 +423,22 @@ static esp_err_t i2c_setup_port(i2c_dev_t *dev) // dev is non-const to update de
             .i2c_port = dev->port,
             .sda_io_num = sda_pin,
             .scl_io_num = scl_pin,
-            .clk_source = I2C_CLK_SRC_DEFAULT,
             .glitch_ignore_cnt = 7,
             .flags.enable_internal_pullup = (sda_pullup || scl_pullup),
             // Bus speed is not set here. It's per-device or a global target for the bus can be set
             // if desired, but i2c_master supports per-device speeds.
         };
+        // LP_I2C requires LP_I2C_SCLK_DEFAULT; HP I2C uses the standard default.
+        // clk_source and lp_source_clk are union members in i2c_master_bus_config_t,
+        // but LP_I2C_SCLK_DEFAULT is not a valid i2c_clock_source_t value, so
+        // i2c_new_master_bus returns ESP_ERR_NOT_SUPPORTED if we pass I2C_CLK_SRC_DEFAULT
+        // for an LP port.
+#if SOC_LP_I2C_SUPPORTED
+        if (dev->port == (i2c_port_t)LP_I2C_NUM_0)
+            bus_config.clk_source = LP_I2C_SCLK_DEFAULT;
+        else
+#endif
+            bus_config.clk_source = I2C_CLK_SRC_DEFAULT;
 
         res = i2c_new_master_bus(&bus_config, &port_state->bus_handle);
         if (res == ESP_OK)


### PR DESCRIPTION
## Summary

Fixes #12.

`i2c_setup_port` hardcoded `.clk_source = I2C_CLK_SRC_DEFAULT` in the
`i2c_master_bus_config_t` initializer. For `LP_I2C_NUM_0` this is the wrong
value: `clk_source` and `lp_source_clk` are union members in the struct, and
`LP_I2C_SCLK_DEFAULT` is not a valid `i2c_clock_source_t` — passing
`I2C_CLK_SRC_DEFAULT` for an LP port causes `i2c_new_master_bus` to return
`ESP_ERR_NOT_SUPPORTED`.

The fix detects the LP port and sets `LP_I2C_SCLK_DEFAULT`, guarded by
`#if SOC_LP_I2C_SUPPORTED` so it is a no-op on chips without LP_I2C.

## Testing

Validated on ESP32-C6 (the only current ESP-IDF target with `SOC_LP_I2C_SUPPORTED`):
a firmware project using i2cdev devices (`INA219`, `BQ27220`) on `LP_I2C_NUM_0`
(GPIO6/GPIO7) now initialises correctly. Previously the first i2cdev transaction
on the LP port returned `ESP_ERR_NOT_SUPPORTED`.

HP I2C behaviour on ESP32-C6 and ESP32-S3 is unchanged — the `else` branch
keeps `I2C_CLK_SRC_DEFAULT` for all HP ports, and the `#if SOC_LP_I2C_SUPPORTED`
guard means the new code is not compiled on chips without LP_I2C.

## Notes

- The official ESP-IDF example for LP_I2C also uses `.clk_source = LP_I2C_SCLK_DEFAULT`
  (not the `.lp_source_clk` field name) — both field names work because they are
  union members, but the value is what matters.
- See also the [ESP-IDF component manager issue](https://github.com/espressif/idf-component-manager/issues/99)
  for context on why we ended up pinning the fork as a submodule while waiting for
  this PR to land.